### PR TITLE
classMessageToRealObjectStub

### DIFF
--- a/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testStubbingRealObjectShouldReturnRealClass.st
+++ b/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testStubbingRealObjectShouldReturnRealClass.st
@@ -1,0 +1,9 @@
+tests
+testStubbingRealObjectShouldReturnRealClass
+
+	| object actual |
+	object := 0@0.
+	object stub.
+
+	actual := object class.
+	actual should be: Point

--- a/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testStubbingRealObjectShouldReturnRealClass.st
+++ b/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testStubbingRealObjectShouldReturnRealClass.st
@@ -6,4 +6,7 @@ testStubbingRealObjectShouldReturnRealClass
 	object stub.
 
 	actual := object class.
-	actual should be: Point
+	actual should be: Point.
+	self assert: (object isKindOf: Point).
+	object should beInstanceOf: Point.
+	object should beKindOf: Point.

--- a/Mocketry-Domain.package/GHVictimMetaMessages.extension/instance/stubDoesNotExpect..st
+++ b/Mocketry-Domain.package/GHVictimMetaMessages.extension/instance/stubDoesNotExpect..st
@@ -1,5 +1,12 @@
 *Mocketry-Domain
 stubDoesNotExpect: anOccurredMessage
+	anOccurredMessage selector == #class ifTrue: [ 
+		"It is special case because we know that #class will return a mutation instance.
+		And we want to avoid it: by default class of infected object should be original class.
+		The meta messages logic does not allow to achieve it 
+		because we want to be able stub #class message too. 
+		Here is default behaviour with idea that #class is normally not overridden"
+		^ GHVictimMetaMessages originalClassOf: anOccurredMessage receiver ].
 	
 	^GHCurrentMetaLevelDepth decreaseFor: [ 	  
 		GHVictimMetaMessages executeOriginalMethodOf: ghost for: anOccurredMessage


### PR DESCRIPTION
Hardcoded logic for default behaviour for #class message to real object stub:
It is special case because we know that #class will return a mutation instance. We want to avoid it: 
- by default class of infected object should be original class.
The meta messages logic does not allow to achieve it  because we want to be able to stub #class message too. 
The  implementation  also relies on the fact that  #class is normally not overridden. But it can be improved in future.