### PR TITLE
4.0.x update

### DIFF
--- a/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testStubbingRealObjectShouldReturnRealClass.st
+++ b/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testStubbingRealObjectShouldReturnRealClass.st
@@ -1,0 +1,9 @@
+tests
+testStubbingRealObjectShouldReturnRealClass
+
+	| object actual |
+	object := 0@0.
+	object stub.
+
+	actual := object class.
+	actual should be: Point

--- a/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testStubbingRealObjectShouldReturnRealClass.st
+++ b/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testStubbingRealObjectShouldReturnRealClass.st
@@ -6,4 +6,7 @@ testStubbingRealObjectShouldReturnRealClass
 	object stub.
 
 	actual := object class.
-	actual should be: Point
+	actual should be: Point.
+	self assert: (object isKindOf: Point).
+	object should beInstanceOf: Point.
+	object should beKindOf: Point.

--- a/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testWillStubRealResult.st
+++ b/Mocketry-Domain-Tests.package/MockAcceptanceTests.class/instance/testWillStubRealResult.st
@@ -1,0 +1,13 @@
+tests
+testWillStubRealResult
+
+	| actual rect |
+	rect := 0@0 corner: 2@4.
+	rect stub center willStubRealResult.
+	
+	actual := rect center.
+	actual hasGHMutation should be: true.
+	actual should equal: 1@2.
+	
+	(Instance of: Point) stub angle willReturn: #constAngle.
+	actual angle should be: #constAngle

--- a/Mocketry-Domain.package/GHVictimMetaMessages.extension/instance/stubDoesNotExpect..st
+++ b/Mocketry-Domain.package/GHVictimMetaMessages.extension/instance/stubDoesNotExpect..st
@@ -1,5 +1,12 @@
 *Mocketry-Domain
 stubDoesNotExpect: anOccurredMessage
+	anOccurredMessage selector == #class ifTrue: [ 
+		"It is special case because we know that #class will return a mutation instance.
+		And we want to avoid it: by default class of infected object should be original class.
+		The meta messages logic does not allow to achieve it 
+		because we want to be able stub #class message too. 
+		Here is default behaviour with idea that #class is normally not overridden"
+		^ GHVictimMetaMessages originalClassOf: anOccurredMessage receiver ].
 	
 	^GHCurrentMetaLevelDepth decreaseFor: [ 	  
 		GHVictimMetaMessages executeOriginalMethodOf: ghost for: anOccurredMessage

--- a/Mocketry-Domain.package/MockDefaultMethods.class/instance/copy.st
+++ b/Mocketry-Domain.package/MockDefaultMethods.class/instance/copy.st
@@ -1,3 +1,3 @@
-copy
+copying
 copy
 	self disableDefaultMethod

--- a/Mocketry-Domain.package/MockDefaultMethods.class/instance/shallowCopy.st
+++ b/Mocketry-Domain.package/MockDefaultMethods.class/instance/shallowCopy.st
@@ -1,3 +1,3 @@
-copy
+copying
 shallowCopy
 	self disableDefaultMethod

--- a/Mocketry-Domain.package/MockExpectedMessage.class/instance/willStubRealResult.st
+++ b/Mocketry-Domain.package/MockExpectedMessage.class/instance/willStubRealResult.st
@@ -1,0 +1,3 @@
+actions
+willStubRealResult
+	self will: MockExpectedMethodResultStub new

--- a/Mocketry-Domain.package/MockExpectedMethodResultStub.class/instance/executeFor..st
+++ b/Mocketry-Domain.package/MockExpectedMethodResultStub.class/instance/executeFor..st
@@ -1,0 +1,6 @@
+evaluating
+executeFor: anOccurredMessage
+	| realMethodResult |
+	realMethodResult := super executeFor: anOccurredMessage.
+	realMethodResult stub.
+	^realMethodResult

--- a/Mocketry-Domain.package/MockExpectedMethodResultStub.class/properties.json
+++ b/Mocketry-Domain.package/MockExpectedMethodResultStub.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "MockExpectedOriginalMethodCall",
+	"category" : "Mocketry-Domain",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "MockExpectedMethodResultStub",
+	"type" : "normal"
+}

--- a/Mocketry-Specs.package/SpecOfExpectedMessage.class/instance/copy.st
+++ b/Mocketry-Specs.package/SpecOfExpectedMessage.class/instance/copy.st
@@ -1,4 +1,4 @@
-accessing
+copying
 copy
 
 	| result |

--- a/Mocketry-Specs.package/SpecOfObjectsInteraction.class/instance/copy.st
+++ b/Mocketry-Specs.package/SpecOfObjectsInteraction.class/instance/copy.st
@@ -1,4 +1,4 @@
-accessing
+copying
 copy
 	| copy |
 	copy := super copy.


### PR DESCRIPTION
- new expected action #willStubRealResult 
- better method protocol names 
- #class message to real object stub return original class of object by default