### PR TITLE
Prevent user mistakes with missing #stub message

### DIFF
--- a/Mocketry-Domain-Tests/MockAcceptanceTests.class.st
+++ b/Mocketry-Domain-Tests/MockAcceptanceTests.class.st
@@ -124,7 +124,13 @@ MockAcceptanceTests >> testBuildingExpectationForMocksReturnedFromMessages [
 MockAcceptanceTests >> testBuildingExpectationWithoutStubShouldAlwaysFail [
 
 	[mock someMessage willReturn: #result]
-		should fail
+		should fail.
+		
+	[mock willReturn: #result]
+		should fail.
+		
+	[mock stub willReturn: #result]
+		should fail.
 ]
 
 { #category : #tests }

--- a/Mocketry-Domain-Tests/MockAcceptanceTests.class.st
+++ b/Mocketry-Domain-Tests/MockAcceptanceTests.class.st
@@ -121,6 +121,13 @@ MockAcceptanceTests >> testBuildingExpectationForMocksReturnedFromMessages [
 ]
 
 { #category : #tests }
+MockAcceptanceTests >> testBuildingExpectationWithoutStubShouldAlwaysFail [
+
+	[mock someMessage willReturn: #result]
+		should fail
+]
+
+{ #category : #tests }
 MockAcceptanceTests >> testBuildingExpectationsByBlock [
 
 	| mock2 |

--- a/Mocketry-Domain/MockBehaviour.class.st
+++ b/Mocketry-Domain/MockBehaviour.class.st
@@ -233,7 +233,10 @@ MockBehaviour >> send: aMessage to: aMockObject [
 				receiver: aMockObject 
 				selector: aMessage selector
 				arguments: aMessage arguments.
-				
+	"Following is a hook to prevent user mistakes do to missing #stub message for expectations. 
+	Check method comment for details"
+	occurredMessage shouldBeAllowedForMock.
+	
 	^mockRole processMessageSend: occurredMessage by: self
 ]
 

--- a/Mocketry-Domain/MockExpectedMessage.class.st
+++ b/Mocketry-Domain/MockExpectedMessage.class.st
@@ -29,9 +29,17 @@ And to specify conditions which should be valid when expectation is executed use
 
 - when: aBlock is: aSpecOfObjectState
 - when: aBlock satisfying: aBlock 
-- shouldOccurInThisThread
-- shouldOccurInAnotherThread 
- 
+- shouldBeSentInThisThread
+- shouldBeSentInAnotherThread 
+
+In addition I mark particular methods with pragma <dontSendToMock>. It allows to prevent user mistakes when expectations are defined without #stub message to the mock. It is easy to do such mistake. So such messages (mock teacher API) are completely forbidden for mocks. For example following expressions fail:
+
+	mock someMessage willReturn: 1.
+	mock will: [2].
+	mock stub willRaise: Error new
+
+It means that users can't stub such messages but it is reasonable restriction.
+
 Internal Representation and Key Implementation Points.
 
     Instance Variables
@@ -49,7 +57,7 @@ Class {
 		'actions',
 		'conditionsSpec'
 	],
-	#category : 'Mocketry-Domain'
+	#category : #'Mocketry-Domain'
 }
 
 { #category : #'instance creation' }
@@ -125,11 +133,13 @@ MockExpectedMessage >> restrictUsage [
 
 { #category : #conditions }
 MockExpectedMessage >> shouldBeSentInAnotherProcess [
+	<dontSendToMock>
 	conditionsSpec addSpec: SpecOfAsynchMessage forActiveProcess
 ]
 
 { #category : #conditions }
 MockExpectedMessage >> shouldBeSentInThisProcess [
+	<dontSendToMock>
 	conditionsSpec addSpec: SpecOfAsynchMessage forActiveProcess not
 ]
 
@@ -178,52 +188,62 @@ MockExpectedMessage >> useTwice [
 ]
 
 { #category : #conditions }
-MockExpectedMessage >> when: subjectBlock is: aSpecOfOBjectState [
-	conditionsSpec addSpec: (SpecOfMessageSendCondition of: subjectBlock by: aSpecOfOBjectState)
+MockExpectedMessage >> when: subjectBlock is: aSpecOfObjectState [
+	<dontSendToMock>
+	conditionsSpec addSpec: (SpecOfMessageSendCondition of: subjectBlock by: aSpecOfObjectState)
 ]
 
 { #category : #conditions }
 MockExpectedMessage >> when: subjectBlock satisfy: conditionBlock [
+	<dontSendToMock>
 	self when: subjectBlock is: (Satisfying for: conditionBlock)
 ]
 
 { #category : #actions }
 MockExpectedMessage >> will: anObject [
+	<dontSendToMock>
 	actions add: anObject asMockExpectationAction
 ]
 
 { #category : #actions }
 MockExpectedMessage >> willCallOriginalMethod [
+	<dontSendToMock>
 	self will: MockExpectedOriginalMethodCall new
 ]
 
 { #category : #actions }
 MockExpectedMessage >> willLogMessage [
+	<dontSendToMock>
 	self will: MockExpectedMessageLogging new
 ]
 
 { #category : #actions }
 MockExpectedMessage >> willRaise: anExceptionOrClass [ 
+	<dontSendToMock>
 	self will: (MockExpectedException exception: anExceptionOrClass)
 ]
 
 { #category : #actions }
 MockExpectedMessage >> willReturn: anObject [ 
+	<dontSendToMock>
 	self will: (MockExpectedValueReturn value: anObject)
 ]
 
 { #category : #actions }
 MockExpectedMessage >> willReturnValueFrom: anArray [ 
+	<dontSendToMock>
 	self will: (MockExpectedValueForForEachCall values: anArray).
 	spec usage maxCount: anArray size
 ]
 
 { #category : #actions }
 MockExpectedMessage >> willReturnYourself [
+	<dontSendToMock>
 	self will: MockExpectedReceiverReturn new
 ]
 
 { #category : #actions }
 MockExpectedMessage >> willStubRealResult [
+	<dontSendToMock>
 	self will: MockExpectedMethodResultStub new
 ]

--- a/Mocketry-Domain/MockOccurredMessage.class.st
+++ b/Mocketry-Domain/MockOccurredMessage.class.st
@@ -152,6 +152,23 @@ MockOccurredMessage >> setUpUnexpectedResult [
 	^self extractResultFrom: [ receiver stubDoesNotExpect: self ]
 ]
 
+{ #category : #controlling }
+MockOccurredMessage >> shouldBeAllowedForMock [
+	"Method is introduced to prevent user mistakes due to missing #stub message.
+	It is easy to forget to send #stub message when defining an expectation for a mock. 
+	So with this method following examples fail with explicit error:
+		mock someMessage willReturn: 3.
+		mock will: [3].
+		mock stub willRaise: Error new"
+	| expectationMethod |
+	expectationMethod := MockExpectedMessage compiledMethodAt: selector ifAbsent: [ ^self ].
+	(expectationMethod hasPragmaNamed: #dontSendToMock) ifFalse: [ ^self ].
+	
+	GHCurrentMetaLevelDepth increaseFor: [
+		self error: '#stub is missing to define expectation using ', selector printString
+	]
+]
+
 { #category : #printing }
 MockOccurredMessage >> stringForResultSpec [
 

--- a/Mocketry-Domain/MockOccurredMessage.class.st
+++ b/Mocketry-Domain/MockOccurredMessage.class.st
@@ -164,8 +164,10 @@ MockOccurredMessage >> shouldBeAllowedForMock [
 	expectationMethod := MockExpectedMessage compiledMethodAt: selector ifAbsent: [ ^self ].
 	(expectationMethod hasPragmaNamed: #dontSendToMock) ifFalse: [ ^self ].
 	
-	GHCurrentMetaLevelDepth increaseFor: [
-		self error: '#stub is missing to define expectation using ', selector printString
+	GHCurrentMetaLevelDepth increaseFor: [ | error |
+		error := receiver ghostBehaviour mockRole isTeaching
+			ifTrue: [ 'Missing expected message (after #stub)' ] ifFalse: [ 'Missing #stub' ].
+		self error: error, ' to define expectation using ', selector printString
 	]
 ]
 

--- a/Mocketry-Domain/MockRole.class.st
+++ b/Mocketry-Domain/MockRole.class.st
@@ -26,6 +26,11 @@ MockRole class >> default [
 	^default ifNil: [ default := self new ]
 ]
 
+{ #category : #testing }
+MockRole >> isTeaching [ 
+	^false
+]
+
 { #category : #processing }
 MockRole >> processMessageSend: anOccurredMessage by: aMockBehaviour [
 	self subclassResponsibility 

--- a/Mocketry-Domain/MockStubTeacher.class.st
+++ b/Mocketry-Domain/MockStubTeacher.class.st
@@ -18,6 +18,11 @@ MockStubTeacher >> anyMessage [
 		Any stub anyMessage willReturn: 10 "
 ]
 
+{ #category : #testing }
+MockStubTeacher >> isTeaching [
+	^true
+]
+
 { #category : #processing }
 MockStubTeacher >> processTransformedMessageSend: anOccurredMessage by: aMockBehaviour [
 	

--- a/Mocketry-Domain/MockTeacher.class.st
+++ b/Mocketry-Domain/MockTeacher.class.st
@@ -11,6 +11,11 @@ Class {
 	#category : 'Mocketry-Domain'
 }
 
+{ #category : #testing }
+MockTeacher >> isTeaching [
+	^true
+]
+
 { #category : #processing }
 MockTeacher >> processMessageSend: anOccurredMessage by: aMockBehaviour [
 


### PR DESCRIPTION
Expectation methods  (teacher API) are marked with pragma \<dontSendToMock\>. Such methods are not allowed to be send to mocks to prevent user mistakes when it forget #stub message with defining an expectation for a mock.  
So now following examples will fail:
```Smalltalk
mock someMessage willReturn: 1.
mock will: [2].
mock stub willRaise: Error new
```