### PR TITLE
test environment updates for Pharo 9

### DIFF
--- a/Mocketry-Domain/MockCleaningProcessHook.class.st
+++ b/Mocketry-Domain/MockCleaningProcessHook.class.st
@@ -20,3 +20,18 @@ MockCleaningProcessHook class >> instance [
 MockCleaningProcessHook >> terminate [
 	MockCurrentBehaviour value: nil
 ]
+
+{ #category : #testing }
+MockCleaningProcessHook >> isSuspended [
+	^false
+]
+
+{ #category : #testing }
+MockCleaningProcessHook >> isTerminated [
+	^MockCurrentBehaviour value isNil
+]
+
+{ #category : #accessing }
+MockCleaningProcessHook >> priority [
+	^Processor activePriority
+]

--- a/Mocketry-Domain/TestExecutionEnvironment.extension.st
+++ b/Mocketry-Domain/TestExecutionEnvironment.extension.st
@@ -9,7 +9,7 @@ TestExecutionEnvironment >> allowsForkedProcessInheritMocks [
 { #category : #'*Mocketry-Domain' }
 TestExecutionEnvironment >> createMockBehaviour [
 	| behaviour |
-	forkedProcesses add: MockCleaningProcessHook instance.
+	self forkedProcesses add: MockCleaningProcessHook instance.
 	
 	behaviour := super createMockBehaviour.
 	behaviour ownerTestCase: testCase.


### PR DESCRIPTION
Updates for compatibility with current development version of Pharo 9. All changes are compatible with Pharo 8 and 7 as well.
Fixes #29 