### PR TITLE
Pharo 13 support. Pharo 11- support dropped

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        smalltalk: [ Pharo64-12, Pharo64-11, Pharo64-10, Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, Pharo32-7.0 ]
+        smalltalk: [ Pharo64-12, Pharo64-13 ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2

--- a/BaselineOfMocketry/BaselineOfMocketry.class.st
+++ b/BaselineOfMocketry/BaselineOfMocketry.class.st
@@ -1,41 +1,51 @@
 Class {
-	#name : #BaselineOfMocketry,
-	#superclass : #BaselineOf,
-	#category : #BaselineOfMocketry
+	#name : 'BaselineOfMocketry',
+	#superclass : 'BaselineOf',
+	#category : 'BaselineOfMocketry',
+	#package : 'BaselineOfMocketry'
 }
 
-{ #category : #baselines }
+{ #category : 'baselines' }
 BaselineOfMocketry >> baseline: spec [
-	<baseline>
-	
-	spec for: #common do: [
-		spec 
-			baseline: 'StateSpecs' with: [spec repository: 'github://dionisiydk/StateSpecs:v5.0.2'];
-			project: 'StateSpecsCore' copyFrom: 'StateSpecs' with: [
-		 	    spec	loads: #('Core' 'GhostSupport')];
-			project: 'StateSpecsTests' copyFrom: 'StateSpecs' with: [
-		 	    spec	loads: #('Tests' 'GhostSupportTests' )];	
-				
-			baseline: 'Ghost' with: [
-		 	    spec repository: 'github://pharo-ide/Ghost:v6.0.2'];
-			project: 'GhostCore' copyFrom: 'Ghost' with: [
-		 	    spec	loads: #('ObjectGhost' 'ToolsSupport' 'ObjectMutation')];
-			project: 'GhostTests' copyFrom: 'Ghost' with: [
-		 	    spec	loads: #('ObjectGhostTests' 'ClassGhostTests' 'ObjectMutationTests')];
-			package: 'Mocketry-Specs' with: [ spec requires: #('StateSpecsCore')];
-			package: 'Mocketry-Domain' with: [ spec requires: #('Mocketry-Specs' 'GhostCore')];
-			package: 'Mocketry-Help' with: [ spec requires: #('Mocketry-Domain')];
-			package: 'Mocketry-Specs-Tests' with: [ 
-				spec requires: #('Mocketry-Specs' 'StateSpecsTests') ];
-			package: 'Mocketry-Domain-Tests' with: [ spec requires: #('Mocketry-Specs' 'GhostTests') ].
-		spec
-			group: 'default' with: #('Core' 'Tests');
-			group: 'Core' with: #('Mocketry-Specs' 'Mocketry-Domain');
-			group: 'Tests' with: #('Mocketry-Specs-Tests' 'Mocketry-Domain-Tests')].
 
+	<baseline>
+	spec for: #common do: [
+			spec
+				baseline: 'StateSpecs'
+				with: [ spec repository: 'github://dionisiydk/StateSpecs:v5.0.3' ];
+				project: 'StateSpecsCore'
+				copyFrom: 'StateSpecs'
+				with: [ spec loads: #( 'Core' 'GhostSupport' ) ];
+				project: 'StateSpecsTests'
+				copyFrom: 'StateSpecs'
+				with: [ spec loads: #( 'Tests' 'GhostSupportTests' ) ];
+				baseline: 'Ghost'
+				with: [ spec repository: 'github://pharo-ide/Ghost:v7.0.1' ];
+				project: 'GhostCore'
+				copyFrom: 'Ghost'
+				with: [
+					spec loads: #( 'ObjectGhost' 'ToolsSupport' 'ObjectMutation' ) ];
+				project: 'GhostTests' copyFrom: 'Ghost' with: [
+						spec loads:
+								#( 'ObjectGhostTests' 'ClassGhostTests' 'ObjectMutationTests' ) ];
+				package: 'Mocketry-Specs'
+				with: [ spec requires: #( 'StateSpecsCore' ) ];
+				package: 'Mocketry-Domain'
+				with: [ spec requires: #( 'Mocketry-Specs' 'GhostCore' ) ];
+				package: 'Mocketry-Help'
+				with: [ spec requires: #( 'Mocketry-Domain' ) ];
+				package: 'Mocketry-Specs-Tests'
+				with: [ spec requires: #( 'Mocketry-Specs' 'StateSpecsTests' ) ];
+				package: 'Mocketry-Domain-Tests'
+				with: [ spec requires: #( 'Mocketry-Specs' 'GhostTests' ) ].
+			spec
+				group: 'default' with: #( 'Core' 'Tests' );
+				group: 'Core' with: #( 'Mocketry-Specs' 'Mocketry-Domain' );
+				group: 'Tests'
+				with: #( 'Mocketry-Specs-Tests' 'Mocketry-Domain-Tests' ) ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BaselineOfMocketry >> projectClass [
 	^ [ self class environment at: #MetacelloCypressBaselineProject ]
 		on: NotFound

--- a/BaselineOfMocketry/package.st
+++ b/BaselineOfMocketry/package.st
@@ -1,1 +1,1 @@
-Package { #name : #BaselineOfMocketry }
+Package { #name : 'BaselineOfMocketry' }

--- a/README.md
+++ b/README.md
@@ -8,25 +8,31 @@
 [![Pharo 9.0](https://img.shields.io/badge/Pharo-9.0-informational)](https://pharo.org)
 [![Pharo 10](https://img.shields.io/badge/Pharo-10-informational)](https://pharo.org)
 [![Pharo 11](https://img.shields.io/badge/Pharo-11-informational)](https://pharo.org)
-[![Pharo 11](https://img.shields.io/badge/Pharo-12-informational)](https://pharo.org)
+[![Pharo 12](https://img.shields.io/badge/Pharo-12-informational)](https://pharo.org)
+[![Pharo 13](https://img.shields.io/badge/Pharo-13-informational)](https://pharo.org)
 
 Mocketry is mock objects framework\. It provides simplest way to stub any message to any object and to verify any occurred behaviour
 
 ## Installation
-Use following script for Pharo version >= 6:
+The installation script (therefore version of StateSpecs) depends on Pharo version you are using it in.
+
+Pharo 13 (master branch):
 ```Smalltalk
 Metacello new
   baseline: 'Mocketry';
-  repository: 'github://dionisiydk/Mocketry';
+  repository: 'github://dionisiydk/Mocketry:master';
   load
 ```
-To add dependency in your project baseline:
+
+Pharo 6-12 (v7.0.2):
 ```Smalltalk
-spec
-    baseline: 'Mocketry'
-    with: [ spec repository: 'github://dionisiydk/Mocketry:versionTagOrBranch' ]
+Metacello new
+  baseline: 'Mocketry';
+  repository: 'github://dionisiydk/Mocketry:v7.0.2';
+  load
 ```
-For old Pharo versions project should be loaded from smalltalkhub:
+
+Pharo <= 5:
 ```Smalltalk
 Metacello new
       smalltalkhubUser: 'dionisiy' project: 'Mocketry';
@@ -34,6 +40,15 @@ Metacello new
       version: #stable;
       load.
 ```
+
+To add dependency in your project baseline:
+```Smalltalk
+spec
+    baseline: 'Mocketry'
+    with: [ spec repository: 'github://dionisiydk/Mocketry:v7.0.2' ].
+```
+(replace the version in the URL depending on Pharo version as shown above with standalone scripts)
+
 ## Create mocks easily
 To create mock just use **\#new**
 ```Smalltalk


### PR DESCRIPTION
* Updated Ghost to v7.0.1 and StateSpecs to v5.0.3, adding Pharo 13 support, but dropping Pharo 11- support
* GH Actions now test in Pharo 12 and 13 instead of 7-11